### PR TITLE
Add the ability to query for the replica status of a PG instance

### DIFF
--- a/haproxy_status.py
+++ b/haproxy_status.py
@@ -18,7 +18,9 @@ class StatusHandler(BaseHTTPRequestHandler):
     def do_OPTIONS(self):
         return self.do_ANY()
     def do_ANY(self):
-        if postgresql.name == etcd.current_leader()["hostname"]:
+        leader = etcd.current_leader()
+        is_leader = leader != None and postgresql.name == leader["hostname"]
+        if ((self.path == "/" or self.path == "/master") and is_leader) or (self.path == "/replica" and not is_leader):
           self.send_response(200)
         else:
           self.send_response(503)


### PR DESCRIPTION
This allows the ELBs to query for the status of a PG instance being either a master or replica.

In this case, it'd query the following URLs:

```
http://127.0.0.1:15432/master
http://127.0.0.1:15432/replica
```

I left in support for requests to `/` with the thinking that we could PR this into the original repo and not break existing integrations.

See https://jira.tapjoy.net/browse/SVCS-2227 for design details.

/to @Tapjoy/eng-group-services 
/cc @jlogsdon 
